### PR TITLE
docs: personalized README + Pages details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # NewsGridResources
 
-![Pages Deploy](https://github.com/eriktong/NewsGridResources/actions/workflows/pages.yml/badge.svg) ![Last commit](https://img.shields.io/github/last-commit/eriktong/NewsGridResources) ![License](https://img.shields.io/badge/license-MIT-informational)
+![Pages Deploy](https://github.com/eriktong/NewsGridResources/actions/workflows/pages.yml/badge.svg) ![Last commit](https://img.shields.io/github/last-commit/eriktong/NewsGridResources) 
 
 **Live Demo:** [https://eriktong.github.io/NewsGridResources/](https://eriktong.github.io/NewsGridResources/)
 
-> Short description: _Update this one-liner to summarize the app in a sentence._
+> News/magazine layout built with modern CSS.
 
 ---
 
 ## Features
-- Clean starter with Static HTML/CSS/JS
+- CSS Grid layout
+- Featured story & categories
+- Article cards
 - Deployed on **GitHub Pages** via Actions
-- Production build output: `.`
-- Mobile-friendly layout _(if applicable)_
-- Routing-ready _(SPA)_  
+- Output dir: `.`
 
 
 ---
@@ -21,15 +21,12 @@
 ## Quick Start
 
 ### Prerequisites
-- Node.js LTS (or none if pure static)
+- Node.js LTS (if using Node/React)
 - npm (bundled with Node)
 
 ### Local Dev
 ```bash
-# install
 npm install
-
-# start dev server
 npx serve .
 ```
 
@@ -38,31 +35,22 @@ npx serve .
 (none)
 ```
 
-> Build output goes to **`.`**.
-
 ---
 
 ## Deploy (GitHub Pages)
+- Public URL: **https://eriktong.github.io/NewsGridResources/**
+- Workflow: `.github/workflows/pages.yml`
 
-This repo deploys using **Actions** on pushes to `master`.
 
-- Workflow: `.github/workflows/pages.yml`  
-- Public URL: **https://eriktong.github.io/NewsGridResources/**  
-- SPA fallback: `404.html` is created during the workflow so React Router routes work on refresh.
-
-If something breaks:
-1. Verify the latest workflow run is green.
-2. For CRA, ensure `"homepage": "https://eriktong.github.io/NewsGridResources/"` exists in `package.json`.
-3. For Vite, ensure `base: "/NewsGridResources/"` in `vite.config.*`.
+If a route 404s on refresh, SPA fallback is already created as `404.html`.
 
 ---
 
 ## Screenshots
-
-> Put images under `docs/` and reference them here.
+Put images under `docs/` and reference them here.
 
 | Screen | Image |
-|---|---|
+| --- | --- |
 | Home | ![Home](docs/screenshot-1.png) |
 
 ---
@@ -74,33 +62,14 @@ If something breaks:
 
 ---
 
-## Project Structure (high level)
-
-
----
-
-## Environment Variables
-> If none, delete this section. Otherwise, document them like:
-
-| Variable | Example | Required | Description |
-|---|---|---|---|
-| `VITE_API_URL` | `https://api.example.com` | No | API base URL |
-
----
-
-## Roadmap / TODO
-- [ ] Add better screenshots
-- [ ] Fill in real description & features
-- [ ] Audit Lighthouse (performance, a11y, SEO)
-- [ ] Add tests (Vitest/Jest) _(optional)_
-- [ ] Add CI for lint/test _(optional)_
+## Project Health Checklist
+- [ ] Update screenshots in `docs/`
+- [ ] Fill in any missing features in this README
+- [ ] Lighthouse pass (perf, a11y, SEO)
+- [ ] Add tests (optional)
 
 ---
 
 ## License
-This project is licensed under the **MIT License**. See [LICENSE](LICENSE).
+If a license exists in this repo, it applies. Otherwise, add one (MIT recommended).
 
----
-
-## Maintainer
-- **Erik Tong** — feedback & issues via GitHub

--- a/README.old.md
+++ b/README.old.md
@@ -1,0 +1,106 @@
+# NewsGridResources
+
+![Pages Deploy](https://github.com/eriktong/NewsGridResources/actions/workflows/pages.yml/badge.svg) ![Last commit](https://img.shields.io/github/last-commit/eriktong/NewsGridResources) ![License](https://img.shields.io/badge/license-MIT-informational)
+
+**Live Demo:** [https://eriktong.github.io/NewsGridResources/](https://eriktong.github.io/NewsGridResources/)
+
+> Short description: _Update this one-liner to summarize the app in a sentence._
+
+---
+
+## Features
+- Clean starter with Static HTML/CSS/JS
+- Deployed on **GitHub Pages** via Actions
+- Production build output: `.`
+- Mobile-friendly layout _(if applicable)_
+- Routing-ready _(SPA)_  
+
+
+---
+
+## Quick Start
+
+### Prerequisites
+- Node.js LTS (or none if pure static)
+- npm (bundled with Node)
+
+### Local Dev
+```bash
+# install
+npm install
+
+# start dev server
+npx serve .
+```
+
+### Build
+```bash
+(none)
+```
+
+> Build output goes to **`.`**.
+
+---
+
+## Deploy (GitHub Pages)
+
+This repo deploys using **Actions** on pushes to `master`.
+
+- Workflow: `.github/workflows/pages.yml`  
+- Public URL: **https://eriktong.github.io/NewsGridResources/**  
+- SPA fallback: `404.html` is created during the workflow so React Router routes work on refresh.
+
+If something breaks:
+1. Verify the latest workflow run is green.
+2. For CRA, ensure `"homepage": "https://eriktong.github.io/NewsGridResources/"` exists in `package.json`.
+3. For Vite, ensure `base: "/NewsGridResources/"` in `vite.config.*`.
+
+---
+
+## Screenshots
+
+> Put images under `docs/` and reference them here.
+
+| Screen | Image |
+|---|---|
+| Home | ![Home](docs/screenshot-1.png) |
+
+---
+
+## Tech Stack
+- Static HTML/CSS/JS
+- HTML, CSS, JavaScript
+- GitHub Actions + GitHub Pages
+
+---
+
+## Project Structure (high level)
+
+
+---
+
+## Environment Variables
+> If none, delete this section. Otherwise, document them like:
+
+| Variable | Example | Required | Description |
+|---|---|---|---|
+| `VITE_API_URL` | `https://api.example.com` | No | API base URL |
+
+---
+
+## Roadmap / TODO
+- [ ] Add better screenshots
+- [ ] Fill in real description & features
+- [ ] Audit Lighthouse (performance, a11y, SEO)
+- [ ] Add tests (Vitest/Jest) _(optional)_
+- [ ] Add CI for lint/test _(optional)_
+
+---
+
+## License
+This project is licensed under the **MIT License**. See [LICENSE](LICENSE).
+
+---
+
+## Maintainer
+- **Erik Tong** — feedback & issues via GitHub


### PR DESCRIPTION
Adds a customized README with per-repo description/features, badges, live demo link, stack-specific quick start, deploy notes, screenshots section, and a project checklist. Existing README (if any) saved as `README.old.md`.